### PR TITLE
seed file runs with users and gear now

### DIFF
--- a/db/seed.js
+++ b/db/seed.js
@@ -1,20 +1,83 @@
+console.log("Running the seed function...");
+
 require("dotenv").config();
 
-import { User } from "../models";
+const User = require("../models").User;
+
+const Gear = require("../models").Gear;
 
 const userSeeds = [
   {
+    id: 1,
     name: "Bob",
     email: "bob@gmail.com",
+    password: "password"
+  },
+  {
+    id: 2,
+    name: "John",
+    email: "john@gmail.com",
     password: "password"
   }
 ];
 
-const seed = () => {
-  return User.bulkCreate(userSeeds);
+const gearSeeds = [
+  {
+    itemName: "Cammenga Tritium Compass 3H",
+    itemDescription: "Day/Night navigation aide",
+    itemWeight: 4,
+    itemStorageLocationion: "garage",
+    itemQuantityInStorage: "1",
+    itemQuantityInPackingList: "0",
+    UserId: 1
+  },
+  {
+    itemName: "Cammenga Tritium Compass 3H",
+    itemDescription: "Day/Night navigation aide",
+    itemWeight: 4,
+    itemStorageLocationion: "garage",
+    itemQuantityInStorage: "1",
+    itemQuantityInPackingList: "0",
+    UserId: 2
+  }
+];
+
+const dropEverything = () => {
+  return Gear.destroy({
+    where: {}
+  }).then(() => {
+    User.destroy({
+      where: {}
+    });
+  });
 };
 
-seed().then(result => {
-  console.log(result);
-  process.exit();
+const seed = () => {
+  return User.bulkCreate(userSeeds).then(
+    result => {
+      return Gear.bulkCreate(gearSeeds).then(
+        result => {
+          console.log("We created the gears!");
+          console.log(result);
+        },
+        error => {
+          console.log("Error creating gears");
+          console.log(error);
+        }
+      );
+    },
+    error => {
+      console.log("There was an error!");
+      console.log(error);
+    }
+  );
+};
+
+console.log("Runnign seed");
+
+dropEverything().then(result => {
+  seed().then(result => {
+    console.log(result);
+    process.exit();
+  });
 });

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ const htmlRoutes = require("./routes/htmlRoutes");
 app.use(htmlRoutes);
 
 // Syncing our database and logging a message to the user upon success, add {force: true} to reset
-db.sequelize.sync().then(() => {
+db.sequelize.sync({force: true}).then(() => {
   app.listen(PORT, () => {
     console.log(
       "==> 🌎  Listening on port %s. Visit http://localhost:%s/ in your browser.",


### PR DESCRIPTION
I worked with a developer friend to complete the seed file functionality. Type "npm run seed" into the terminal while the server is listening and the seed file will run. 

**NOTE: The file is coded to wipe the database and then reseed.** 

This is desirable for testing, but keep it mind that when the seed is run, it will make the database resemble the file everytime.  